### PR TITLE
Fix get_platform import error

### DIFF
--- a/miele/__init__.py
+++ b/miele/__init__.py
@@ -6,11 +6,11 @@ import logging
 
 from aiohttp import web
 from datetime import timedelta
+from importlib import import_module
 
 import voluptuous as vol
 
 from homeassistant.core import callback
-from homeassistant.loader import get_platform
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.entity import Entity
@@ -146,7 +146,7 @@ async def async_setup(hass, config):
                device.async_schedule_update_ha_state(True)
 
             for component in MIELE_COMPONENTS:
-                platform = get_platform(hass, component, DOMAIN)
+                platform = import_module('.{}'.format(component), __name__)
                 platform.update_device_state()
 
     register_services(hass)


### PR DESCRIPTION
This patch fixes this import error on load:

Traceback (most recent call last):
  File "<py_install_dir>/lib/python3.7/site-packages/homeassistant/loader.py", line 263, in _load_file
    module = importlib.import_module(path)
  File "<py_install_dir>/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<home_assistant_install_dir>/custom_components/miele/__init__.py", line 13, in <module>
    from homeassistant.loader.Integration import get_platform

Based on: https://github.com/home-assistant/home-assistant/issues/23009